### PR TITLE
Fix profile url backend & fix avatar upload using s3

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -84,10 +84,10 @@ class ProfileUpdateRequest(BaseModel):
     location: Optional[str] = None
     bio: Optional[str] = None
     email: Optional[EmailStr] = None
-    website: Optional[HttpUrl] = None
-    github: Optional[HttpUrl] = None
-    twitter: Optional[HttpUrl] = None
-    linkedin: Optional[HttpUrl] = None
+    website: Optional[str] = None
+    github: Optional[str] = None
+    twitter: Optional[str] = None
+    linkedin: Optional[str] = None
     avatar_url: Optional[str] = None
 
 


### PR DESCRIPTION
This pull request refactors profile update and avatar upload functionality to improve user experience and migrate avatar storage from local disk to Amazon S3. It introduces smarter normalization of social profile URLs, expands image format support, and enhances error handling and logging for avatar uploads and deletions.

**Profile update improvements:**

* Added a `normalize_url` helper to intelligently convert user-entered social profile and website fields into proper URLs, accepting both usernames and full URLs for GitHub, Twitter, LinkedIn, and website fields.
* Changed `ProfileUpdateRequest` schema fields for `website`, `github`, `twitter`, and `linkedin` from `HttpUrl` to `str` to allow flexible input formats, such as usernames or partial URLs.

**Avatar upload and storage enhancements:**

* Migrated avatar uploads from local disk storage to Amazon S3, including new `upload_avatar` and `delete_avatar` methods in `s3_service`, and updated the avatar upload API to use these methods. This supports more image formats (`webp` added) and generates unique S3 URLs for avatars. [[1]](diffhunk://#diff-1c154e50bf3d928d46d47add2a9384d6baf4a94b15c53767ace97ebb55709d84L111-R186) [[2]](diffhunk://#diff-884a5fc00ed8d7b13575718758b7949f765af0b9660f512bfb6799dfc3dac48eR108-R159)
* Added robust error handling and logging for avatar uploads and deletions, ensuring failures are logged and surfaced as HTTP errors when necessary. [[1]](diffhunk://#diff-1c154e50bf3d928d46d47add2a9384d6baf4a94b15c53767ace97ebb55709d84R195-R204) [[2]](diffhunk://#diff-1c154e50bf3d928d46d47add2a9384d6baf4a94b15c53767ace97ebb55709d84R9-R18)

**S3 service improvements:**

* Expanded content type mapping in S3 service to support all major avatar image formats (`jpg`, `jpeg`, `png`, `gif`, `webp`).